### PR TITLE
Use Sdk as runtime

### DIFF
--- a/dev.lapce.lapce.yaml
+++ b/dev.lapce.lapce.yaml
@@ -1,5 +1,5 @@
 app-id: dev.lapce.lapce
-runtime: org.freedesktop.Platform
+runtime: org.freedesktop.Sdk
 runtime-version: 21.08
 sdk: org.freedesktop.Sdk
 sdk-extensions:


### PR DESCRIPTION
For development apps using Sdk as runtime may make more sense as this adds access to development specific tools in runtime and allows using Sdk extensions like rust.