### PR TITLE
Use host filesystem permission

### DIFF
--- a/dev.lapce.lapce.yaml
+++ b/dev.lapce.lapce.yaml
@@ -7,7 +7,7 @@ sdk-extensions:
 command: lapce
 finish-args:
   - --device=dri
-  - --filesystem=home
+  - --filesystem=host
   - --share=ipc
   - --share=network
   - --socket=wayland


### PR DESCRIPTION
This is useful if your code is on a directory mounted at e.g. /mnt. Currently, if you open a directory residing anywhere but your home, the terminal does not work. I opened an issue about this upstream in Lapce: https://github.com/lapce/lapce/issues/1224