### PR TITLE
Build with LTO

### DIFF
--- a/dev.lapce.lapce.yaml
+++ b/dev.lapce.lapce.yaml
@@ -24,8 +24,8 @@ modules:
     buildsystem: simple
     build-commands:
       - cargo --offline fetch --manifest-path Cargo.toml --verbose
-      - cargo --offline build --no-default-features -p lapce-ui --features all-languages --release --verbose
-      - install -Dm0755 target/release/lapce /app/bin/lapce
+      - cargo --offline build --no-default-features -p lapce-ui --features all-languages --profile release-lto --verbose
+      - install -Dm0755 target/release-lto/lapce /app/bin/lapce
       - install -Dm0644 extra/images/logo_color.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
       - install -Dm0644 extra/linux/${FLATPAK_ID}.desktop /app/share/applications/${FLATPAK_ID}.desktop
       - install -Dm0644 extra/linux/${FLATPAK_ID}.metainfo.xml /app/share/metainfo/${FLATPAK_ID}.metainfo.xml


### PR DESCRIPTION
Reduces binary size but increases built time.

Local test result with upstream commit cb7b8ac on AMD Ryzen 7 PRO 5850U:

- GNU ld, profile release
  build time: 327.77 secs
  Lapce binary size: 80M

- GNU ld, profile release-lto
  build time:  511.54 secs
  Lapce binary size: 73M